### PR TITLE
Fixing memory allocation bounds if using  GCC 11.2 or earlier

### DIFF
--- a/src/basal_mass_balance/BMB_parameterised.f90
+++ b/src/basal_mass_balance/BMB_parameterised.f90
@@ -96,6 +96,64 @@ CONTAINS
 
   END SUBROUTINE run_BMB_model_parameterised_Favier2019
 
+  SUBROUTINE run_BMB_model_parameterised_Favier2019slope( mesh, ice, ocean, BMB)
+    ! The basal melt parameterisation used in Favier et al. (2019)
+    ! Including the dependency on the slope of the ice shelf base
+
+    ! In/output variables
+    TYPE(type_mesh),                     INTENT(IN)    :: mesh
+    TYPE(type_ice_model),                INTENT(IN)    :: ice
+    TYPE(type_ocean_model),              INTENT(IN)    :: ocean
+    TYPE(type_BMB_model),                INTENT(INOUT) :: BMB
+
+    ! Local variables:
+    CHARACTER(LEN=256), PARAMETER                      :: routine_name = 'run_BMB_model_parameterised_Favier2019slope'
+    INTEGER                                            :: vi
+    REAL(dp)                                           :: dT
+    real(dp), dimension(:    ), allocatable            :: dHb_dx, dHb_dy
+    real(dp)                                           :: slope_angle
+
+    ! Add routine to path
+    CALL init_routine( routine_name)
+
+    ! Initialise
+    BMB%BMB_shelf = 0._dp
+    allocate( dHb_dx(   mesh%vi1:mesh%vi2         ))
+    allocate( dHb_dy(   mesh%vi1:mesh%vi2         ))
+    call ddx_a_a_2D( mesh, ice%Hb    , dHb_dx  )
+    call ddy_a_a_2D( mesh, ice%Hb    , dHb_dy  )
+
+    DO vi = mesh%vi1, mesh%vi2
+
+      ! Temperature forcing
+      dT = ocean%T_draft( vi) - ocean%T_freezing_point( vi)
+
+      ! ice shelf draft angle
+      slope_angle = ATAN(SQRT(dHb_dx(vi)**2._dp + dHb_dy(vi)**2._dp))
+
+      ! Favier et al. (2019), Eq. 4
+      ! Altered to allow for negative basal melt (i.e. refreezing) when dT < 0
+      BMB%BMB_shelf( vi) =  -1._dp * sec_per_year * C%BMB_Favier2019_gamma * SIGN(dT,1._dp) * (seawater_density * cp_ocean * dT / (ice_density * L_fusion))**2._dp
+      BMB%BMB_shelf( vi) = BMB%BMB_shelf( vi) * SIN(slope_angle)
+
+      ! Apply grounded fractions
+      IF (ice%mask_gl_gr( vi) .AND. ice%Hib(vi) < ice%SL(vi)) THEN
+        ! Subgrid basal melt rate
+        ! BMB%BMB_shelf( vi) = (1._dp - ice%fraction_gr( vi)) * BMB%BMB_shelf( vi)
+        ! Limit it to only melt (refreezing is tricky)
+        BMB%BMB_shelf( vi) = MAX( BMB%BMB_shelf( vi), 0._dp)
+      END IF
+
+    END DO
+
+    deallocate( dHb_dx)
+    deallocate( dHb_dy)
+
+    ! Finalise routine path
+    CALL finalise_routine( routine_name)
+
+  END SUBROUTINE run_BMB_model_parameterised_Favier2019slope
+
   SUBROUTINE initialise_BMB_model_parameterised( mesh, BMB)
     ! Initialise the BMB model
     !

--- a/src/basal_mass_balance/BMB_parameterised.f90
+++ b/src/basal_mass_balance/BMB_parameterised.f90
@@ -14,7 +14,7 @@ MODULE BMB_parameterised
   USE ice_model_types                                        , ONLY: type_ice_model
   USE ocean_model_types                                      , ONLY: type_ocean_model
   USE BMB_model_types                                        , ONLY: type_BMB_model
-
+  use mesh_disc_apply_operators, only: ddx_a_a_2D, ddy_a_a_2D
   IMPLICIT NONE
 
 CONTAINS

--- a/src/basal_mass_balance/BMB_parameterised.f90
+++ b/src/basal_mass_balance/BMB_parameterised.f90
@@ -43,6 +43,8 @@ CONTAINS
     SELECT CASE (C%choice_BMB_model_parameterised)
       CASE ('Favier2019')
         CALL run_BMB_model_parameterised_Favier2019( mesh, ice, ocean, BMB)
+      CASE ('Favier2019slope')
+        CALL run_BMB_model_parameterised_Favier2019slope( mesh, ice, ocean, BMB)
       CASE DEFAULT
         CALL crash('unknown choice_BMB_model_parameterised "' // TRIM( C%choice_BMB_model_parameterised) // '"')
     END SELECT
@@ -176,6 +178,8 @@ CONTAINS
     ! Initialise the chosen parameterised BMB model
     SELECT CASE (C%choice_BMB_model_parameterised)
       CASE ('Favier2019')
+        ! No need to do anything
+      CASE ('Favier2019slope')
         ! No need to do anything
       CASE DEFAULT
         CALL crash('unknown choice_BMB_model_parameterised "' // TRIM( C%choice_BMB_model_parameterised) // '"')

--- a/src/ice_dynamics/conservation_of_momentum/hybrid_DIVA_BPA/hybrid_DIVA_BPA_main.f90
+++ b/src/ice_dynamics/conservation_of_momentum/hybrid_DIVA_BPA/hybrid_DIVA_BPA_main.f90
@@ -617,7 +617,7 @@ contains
     ! Gather partial gridded data to the primary and broadcast the total field to all processes
     allocate( mask_int_grid( grid%nx, grid%ny))
     call gather_gridded_data_to_primary( grid, mask_int_grid_vec_partial, mask_int_grid)
-    call MPI_BCAST( mask_int_grid, grid%nx * grid%ny, MPI_integer, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( mask_int_grid(:,:), grid%nx * grid%ny, MPI_integer, 0, MPI_COMM_WORLD, ierr)
 
     ! Calculate logical mask (assumes data from file is integer 0 for FALSE and integer 1 for true)
     allocate( mask_grid( grid%nx, grid%ny), source = .false.)

--- a/src/ice_dynamics/utilities/bedrock_cumulative_density_functions.f90
+++ b/src/ice_dynamics/utilities/bedrock_cumulative_density_functions.f90
@@ -231,7 +231,7 @@ contains
     ! Get complete gridded bedrock elevation on all processes
     allocate( Hb_grid_tot( refgeo%grid_raw%nx, refgeo%grid_raw%ny))
     call gather_gridded_data_to_primary( refgeo%grid_raw, refgeo%Hb_grid_raw, Hb_grid_tot)
-    call MPI_BCAST( Hb_grid_tot, refgeo%grid_raw%nx * refgeo%grid_raw%ny, MPI_doUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( Hb_grid_tot(:,:), refgeo%grid_raw%nx * refgeo%grid_raw%ny, MPI_doUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! allocate memory for list of bedrock elevations
     allocate( Hb_list( refgeo%grid_raw%nx * refgeo%grid_raw%ny ))
@@ -350,7 +350,7 @@ contains
     ! Get complete gridded bedrock elevation on all processes
     allocate( Hb_grid_tot( refgeo%grid_raw%nx, refgeo%grid_raw%ny))
     call gather_gridded_data_to_primary( refgeo%grid_raw, refgeo%Hb_grid_raw, Hb_grid_tot)
-    call MPI_BCAST( Hb_grid_tot, refgeo%grid_raw%nx * refgeo%grid_raw%ny, MPI_doUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( Hb_grid_tot(:,:), refgeo%grid_raw%nx * refgeo%grid_raw%ny, MPI_doUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! allocate memory for list of bedrock elevations
     allocate( Hb_list( refgeo%grid_raw%nx * refgeo%grid_raw%ny ))

--- a/src/io/netcdf_basic/netcdf_find_timeframe.f90
+++ b/src/io/netcdf_basic/netcdf_find_timeframe.f90
@@ -52,7 +52,7 @@ contains
 
     ! Read time from file
     call read_var_primary( filename, ncid, id_var_time, time_from_file)
-    call MPI_BCAST( time_from_file, nt, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( time_from_file(:), nt, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Find timeframe closest to desired time
     if (time_from_file( 1) > time) then
@@ -184,7 +184,7 @@ contains
 
     ! Read time from file
     call read_var_primary( filename, ncid, id_var_time, time_from_file)
-    call MPI_BCAST( time_from_file, nt, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( time_from_file(:), nt, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Set the timeframe to the last one in this file
     time_to_read = time_from_file( nt)

--- a/src/io/netcdf_input/netcdf_determine_indexing.f90
+++ b/src/io/netcdf_input/netcdf_determine_indexing.f90
@@ -11,7 +11,7 @@ module netcdf_determine_indexing
 
   private
 
-  public :: determine_xy_indexing, determine_lonlat_indexing, determine_lat_indexing
+  public :: determine_xy_indexing, determine_lonlat_indexing
 
 contains
 
@@ -57,8 +57,8 @@ contains
     ! Read x and y
     call read_var_primary(  filename, ncid, id_var_x, x)
     call read_var_primary(  filename, ncid, id_var_y, y)
-    call MPI_BCAST( x, nx, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( y, ny, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( x(:), nx, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( y(:), ny, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Determine directions of x and y
     if (x( 2) > x( 1)) then
@@ -135,8 +135,8 @@ contains
     ! Read lon and lat
     call read_var_primary(  filename, ncid, id_var_lon, lon)
     call read_var_primary(  filename, ncid, id_var_lat, lat)
-    call MPI_BCAST( lon, nlon, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( lat, nlat, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( lon(:), nlon, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( lat(:), nlat, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Determine directions of x and y
     if (lon( 2) > lon( 1)) then
@@ -170,67 +170,5 @@ contains
     call finalise_routine( routine_name)
 
   end subroutine determine_lonlat_indexing
-
-  subroutine determine_lat_indexing( filename, ncid, var_name, latdir)
-    !< Determine the indexing and dimension directions of a variable in a lat-only grid file
-
-    ! In/output variables:
-    character(len=*),    intent(in   ) :: filename
-    integer,             intent(in   ) :: ncid
-    character(len=*),    intent(in   ) :: var_name
-    character(len=1024), intent(  out) :: latdir
-
-    ! Local variables:
-    character(len=1024), parameter         :: routine_name = 'determine_lat_indexing'
-    integer                                :: id_dim_lat
-    integer                                :: nlat
-    real(dp), dimension(:), allocatable    :: lat
-    integer                                :: ierr
-    integer                                :: id_var_lat, id_var
-    integer, dimension( NF90_MAX_VAR_DIMS) :: dims_of_var
-
-    ! Add routine to path
-    call init_routine( routine_name)
-
-    ! Check if the lat dimension and variables of this file are valid
-    call check_lat( filename, ncid)
-
-    ! Inquire lat dimension
-    call inquire_dim_multopt( filename, ncid, field_name_options_lat, id_dim_lat, dim_length = nlat)
-
-    ! allocate memory for lon and lat
-    allocate( lat( nlat))
-
-    ! Inquire lon and lon variables
-    call inquire_var_multopt( filename, ncid, field_name_options_lat, id_var_lat)
-
-    ! Read lon and lat
-    call read_var_primary(  filename, ncid, id_var_lat, lat)
-    call MPI_BCAST( lat, nlat, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-
-    ! Determine direction of y
-    if (lat( 2) > lat( 1)) then
-      latdir = 'normal'
-    else
-      latdir = 'reverse'
-    end if
-
-    ! Inquire dimensions of the specified field variable
-    call inquire_var_multopt( filename, ncid, var_name, id_var, dims_of_var = dims_of_var)
-
-    ! Determine indexing
-    if (dims_of_var( 1) == id_dim_lat) then
-      ! do nothing, it's all good
-    else
-      call crash('latitude is not the first dimension of variable "' // trim( var_name) // '" in file "' // trim( filename) // '"!')
-    end if
-
-    ! Clean up after yourself
-    deallocate( lat)
-
-    ! Finalise routine path
-    call finalise_routine( routine_name)
-
-  end subroutine determine_lat_indexing
 
 end module netcdf_determine_indexing

--- a/src/io/netcdf_input/netcdf_setup_grid_mesh_from_file.f90
+++ b/src/io/netcdf_input/netcdf_setup_grid_mesh_from_file.f90
@@ -4,8 +4,8 @@ module netcdf_setup_grid_mesh_from_file
   use mpi_f08, only: MPI_COMM_WORLD, MPI_BCAST, MPI_DOUBLE_PRECISION
   use precisions, only: dp
   use mpi_basic, only: par
-  use control_resources_and_error_messaging, only: init_routine, finalise_routine, crash, insert_val_into_string_int
-  use grid_types, only: type_grid, type_grid_lonlat, type_grid_lat
+  use control_resources_and_error_messaging, only: init_routine, finalise_routine, crash
+  use grid_types, only: type_grid, type_grid_lonlat
   use mesh_types, only: type_mesh
   use mesh_memory, only: allocate_mesh_primary
   use mesh_parallel_creation, only: broadcast_mesh
@@ -21,7 +21,7 @@ module netcdf_setup_grid_mesh_from_file
   private
 
   public :: setup_xy_grid_from_file, setup_lonlat_grid_from_file, setup_mesh_from_file, &
-    setup_zeta_from_file, setup_depth_from_file, setup_lonlat_grid_from_lat_file
+    setup_zeta_from_file, setup_depth_from_file
 
 contains
 
@@ -67,8 +67,8 @@ contains
     call read_var_primary(  filename, ncid, id_var_y, grid%y)
 
     ! Broadcast x and y from the primary to the other processes
-    call MPI_BCAST( grid%x, grid%nx, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( grid%y, grid%ny, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( grid%x(:), grid%nx, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( grid%y(:), grid%ny, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Calculate secondary grid geometry data
     call calc_secondary_grid_data( grid)
@@ -119,8 +119,8 @@ contains
     call read_var_primary( filename, ncid, id_var_lat, grid%lat)
 
     ! Broadcast x and y from the primary to the other processes
-    call MPI_BCAST( grid%lon, grid%nlon, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( grid%lat, grid%nlat, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( grid%lon(:), grid%nlon, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( grid%lat(:), grid%nlat, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Secondary data
     call calc_lonlat_field_to_vector_form_translation_tables( grid)
@@ -274,7 +274,7 @@ contains
     call read_var_primary( filename, ncid, id_var_zeta, zeta)
 
     ! Broadcast zeta from primary to all other processes
-    call MPI_BCAST( zeta, nzeta, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( zeta(:), nzeta, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)
@@ -314,75 +314,11 @@ contains
     call read_var_primary( filename, ncid, id_var_depth, depth)
 
     ! Broadcast depth from primary to all other processes
-    call MPI_BCAST( depth, ndepth, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( depth(:), ndepth, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)
 
   end subroutine setup_depth_from_file
-
-  subroutine setup_lonlat_grid_from_lat_file( filename, ncid, grid, vec)
-    !< Set up a lat-only and a lon/lat-grid from a NetCDF file
-
-    ! In/output variables:
-    character(len=*),       intent(in   ) :: filename
-    integer,                intent(in   ) :: ncid
-    type(type_grid_lonlat), intent(  out) :: grid
-    type(type_grid_lat),    intent(  out) :: vec
-
-    ! Local variables:
-    character(len=1024), parameter       :: routine_name = 'setup_lonlat_grid_from_lat_file'
-    integer                              :: id_dim_lat
-    integer                              :: id_var_lat
-    integer                              :: ierr, i
-    integer, parameter                   :: nlon = 360
-    real(dp), parameter                  :: dlon = 1.0
-    real(dp), allocatable, dimension(:)  :: lon
-    CHARACTER(LEN=256)                   :: str
-
-    ! Add routine to path
-    call init_routine( routine_name)
-
-  ! Give the grid a nice name
-    grid%name = 'lonlat_grid_from_file_"' // trim( filename) // '"'
-
-    ! Generate the vector of longitudes - hardcoded to be at 1 degree resolution
-    grid%nlon = nlon
-    allocate( grid%lon( grid%nlon))
-    do i=1, nlon
-        !lon(i) = -180 + 360 * (i - 1) / (nlon - 1) ! longitude going from -180 to + 180
-        grid%lon(i) = i*dlon                             ! longitude going from 0 to 360
-    end do
-
-    ! Check latitude grid dimension and variables for validity
-    call check_lat( filename, ncid)
-
-    ! Inquire lat dimension
-    call inquire_dim_multopt( filename, ncid, field_name_options_lat, id_dim_lat, dim_length = grid%nlat)
-    vec%nlat  = grid%nlat
-
-    ! allocate memory for lat
-    allocate( grid%lat( grid%nlat))
-    allocate(  vec%lat(  vec%nlat))
-
-    ! Inquire lat variable
-    call inquire_var_multopt( filename, ncid, field_name_options_lat, id_var_lat)
-
-    ! Read and assign y
-    call read_var_primary( filename, ncid, id_var_lat, vec%lat)
-    grid%lat  = vec%lat
-
-    ! Broadcast x and y from the master to the other processes
-    call MPI_BCAST( grid%lon, grid%nlon, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( grid%lat, grid%nlat, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST(  vec%lat,  vec%nlat, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-
-    ! Secondary data
-    call calc_lonlat_field_to_vector_form_translation_tables( grid)
-
-
-    ! Finalise routine path
-    call finalise_routine( routine_name)
-  end subroutine setup_lonlat_grid_from_lat_file
 
 end module netcdf_setup_grid_mesh_from_file

--- a/src/io/transects/transects_main.f90
+++ b/src/io/transects/transects_main.f90
@@ -483,7 +483,7 @@ contains
       end do
       close( unit  = 1337)
     end if
-    call MPI_BCAST( waypoints, n_wp*2, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( waypoints(:,:), n_wp*2, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)

--- a/src/mesh/creation/reduce_ice_geometry.f90
+++ b/src/mesh/creation/reduce_ice_geometry.f90
@@ -211,8 +211,8 @@ contains
     end if
 
     ! Broadcast polygons to all processes
-    call MPI_BCAST( poly_mult_sheet, n_poly_mult_sheet*2, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( poly_mult_shelf, n_poly_mult_shelf*2, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( poly_mult_sheet(:,:), n_poly_mult_sheet*2, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( poly_mult_shelf(:,:), n_poly_mult_shelf*2, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Broadcast line sizes to all processes
     call MPI_BCAST( n_line_grounding_line, 1, MPI_integer, 0, MPI_COMM_WORLD, ierr)
@@ -229,10 +229,10 @@ contains
     end if
 
     ! Broadcast lines to all processes
-    call MPI_BCAST( p_line_grounding_line, n_line_grounding_line*4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( p_line_calving_front , n_line_calving_front *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( p_line_ice_front     , n_line_ice_front     *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( p_line_coastline     , n_line_coastline     *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( p_line_grounding_line(:,:), n_line_grounding_line*4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( p_line_calving_front(:,:) , n_line_calving_front *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( p_line_ice_front(:,:)     , n_line_ice_front     *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( p_line_coastline(:,:)     , n_line_coastline     *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)
@@ -384,8 +384,8 @@ contains
     end if
 
     ! Broadcast polygons to all processes
-    call MPI_BCAST( poly_mult_sheet, n_poly_mult_sheet*2, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( poly_mult_shelf, n_poly_mult_shelf*2, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( poly_mult_sheet(:,:), n_poly_mult_sheet*2, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( poly_mult_shelf(:,:), n_poly_mult_shelf*2, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Broadcast line sizes to all processes
     call MPI_BCAST( n_line_grounding_line, 1, MPI_integer, 0, MPI_COMM_WORLD, ierr)
@@ -402,10 +402,10 @@ contains
     end if
 
     ! Broadcast lines to all processes
-    call MPI_BCAST( p_line_grounding_line, n_line_grounding_line*4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( p_line_calving_front , n_line_calving_front *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( p_line_ice_front     , n_line_ice_front     *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    call MPI_BCAST( p_line_coastline     , n_line_coastline     *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( p_line_grounding_line(:,:), n_line_grounding_line*4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( p_line_calving_front(:,:) , n_line_calving_front *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( p_line_ice_front(:,:)     , n_line_ice_front     *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    call MPI_BCAST( p_line_coastline(:,:)     , n_line_coastline     *4, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Finalise routine path
     call finalise_routine( routine_name)

--- a/src/mesh/mesh_parallel_creation.f90
+++ b/src/mesh/mesh_parallel_creation.f90
@@ -84,17 +84,17 @@ CONTAINS
     CALL MPI_BCAST( mesh%beta_stereo, 1                , MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Vertex data
-    CALL MPI_BCAST( mesh%V          , nV_mem   * 2     , MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-    CALL MPI_BCAST( mesh%nC         , nV_mem           , MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
-    CALL MPI_BCAST( mesh%C          , nV_mem   * nC_mem, MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
-    CALL MPI_BCAST( mesh%niTri      , nV_mem           , MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
-    CALL MPI_BCAST( mesh%iTri       , nV_mem   * nC_mem, MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
-    CALL MPI_BCAST( mesh%VBI        , nV_mem           , MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
+    CALL MPI_BCAST( mesh%V(:,:)          , nV_mem   * 2     , MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    CALL MPI_BCAST( mesh%nC(:)         , nV_mem           , MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
+    CALL MPI_BCAST( mesh%C(:,:)          , nV_mem   * nC_mem, MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
+    CALL MPI_BCAST( mesh%niTri(:)      , nV_mem           , MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
+    CALL MPI_BCAST( mesh%iTri(:,:)       , nV_mem   * nC_mem, MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
+    CALL MPI_BCAST( mesh%VBI(:)        , nV_mem           , MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
 
     ! Triangle data
-    CALL MPI_BCAST( mesh%Tri        , nTri_mem * 3     , MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
-    CALL MPI_BCAST( mesh%TriC       , nTri_mem * 3     , MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
-    CALL MPI_BCAST( mesh%Tricc      , nTri_mem * 2     , MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+    CALL MPI_BCAST( mesh%Tri(:,:)        , nTri_mem * 3     , MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
+    CALL MPI_BCAST( mesh%TriC(:,:)       , nTri_mem * 3     , MPI_INTEGER         , 0, MPI_COMM_WORLD, ierr)
+    CALL MPI_BCAST( mesh%Tricc(:,:)      , nTri_mem * 2     , MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
 
     ! Finalise routine path
     CALL finalise_routine( routine_name)


### PR DESCRIPTION
Fixing issue #247 

The same problem might appear in different parts of the code that were not used during the test run(s) in ARCHER2, but the fix should be the same as done here.